### PR TITLE
Add Procfile.dev to ease local development

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rails server -p 3000
+worker: bundler exec sidekiq

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ rails db:create
 rails db:setup
 ```
 
-```
-$ rails s
+Then run Procfile.dev via foreman to start the web (rails) and worker (sidekiq)
+services:
+
+```bash
+foreman start -f Procfile.dev
 ```
 
 ## Did You Change Models?

--- a/bin/setup
+++ b/bin/setup
@@ -31,6 +31,7 @@ fi
 # STEP 2
 printf "${CLEAR_LINE}[2/${STEPS}]  installing gems"
 bundle install > /dev/null
+gem install foreman
 
 # STEP 3
 printf "${CLEAR_LINE}[3/${STEPS}]  adding remotes"


### PR DESCRIPTION
Sarah and I were QA'ing an event sent from a not-yet-deployed version of
exchange to pulse. At some point, we realized that an event wasn't sent
to RabbitMQ because my local sidekiq wasn't running.

* Add a Procfile.dev to make it easier to remember the
system-level dependencies needed to this service.
* Document usage of Procfile.dev in README
* Add `gem install foreman` to bin/setup